### PR TITLE
add build configuration parameter

### DIFF
--- a/SharpTools.SseServer/Program.cs
+++ b/SharpTools.SseServer/Program.cs
@@ -153,7 +153,7 @@ public class Program {
                     var editorConfigProvider = app.Services.GetRequiredService<IEditorConfigProvider>();
 
                     Log.Information("Loading solution: {SolutionPath}", solutionPath);
-                    await solutionManager.LoadSolutionAsync(solutionPath, CancellationToken.None);
+                    await solutionManager.LoadSolutionAsync(solutionPath, "Debug", CancellationToken.None);
 
                     var solutionDir = Path.GetDirectoryName(solutionPath);
                     if (!string.IsNullOrEmpty(solutionDir)) {

--- a/SharpTools.StdioServer/Program.cs
+++ b/SharpTools.StdioServer/Program.cs
@@ -127,7 +127,7 @@ public static class Program {
                     var editorConfigProvider = host.Services.GetRequiredService<IEditorConfigProvider>();
 
                     Log.Information("Loading solution: {SolutionPath}", solutionPath);
-                    await solutionManager.LoadSolutionAsync(solutionPath, CancellationToken.None);
+                    await solutionManager.LoadSolutionAsync(solutionPath, "Debug", CancellationToken.None);
 
                     var solutionDir = Path.GetDirectoryName(solutionPath);
                     if (!string.IsNullOrEmpty(solutionDir)) {

--- a/SharpTools.Tools/Interfaces/ISolutionManager.cs
+++ b/SharpTools.Tools/Interfaces/ISolutionManager.cs
@@ -6,7 +6,7 @@ public interface ISolutionManager : IDisposable {
     MSBuildWorkspace? CurrentWorkspace { get; }
     Solution? CurrentSolution { get; }
 
-    Task LoadSolutionAsync(string solutionPath, CancellationToken cancellationToken);
+    Task LoadSolutionAsync(string solutionPath, string buildConfiguration, CancellationToken cancellationToken);
     void UnloadSolution();
 
     Task<ISymbol?> FindRoslynSymbolAsync(string fullyQualifiedName, CancellationToken cancellationToken);

--- a/SharpTools.Tools/Mcp/Tools/SolutionTools.cs
+++ b/SharpTools.Tools/Mcp/Tools/SolutionTools.cs
@@ -36,12 +36,13 @@ public static class SolutionTools {
 
     [McpServerTool(Name = ToolHelpers.SharpToolPrefix + nameof(LoadSolution), Idempotent = true, Destructive = false, OpenWorld = false, ReadOnly = true)]
     [Description(LoadSolutionDescriptionText)]
-    public static async Task<object> LoadSolution(
-    ISolutionManager solutionManager,
-    IEditorConfigProvider editorConfigProvider,
-    ILogger<SolutionToolsLogCategory> logger,
-    [Description("The absolute file path to the .sln solution file.")] string solutionPath,
-    CancellationToken cancellationToken) {
+    public static async Task<object> LoadSolution(ISolutionManager solutionManager,
+        IEditorConfigProvider editorConfigProvider,
+        ILogger<SolutionToolsLogCategory> logger,
+        [Description("The absolute file path to the .sln solution file.")] string solutionPath,
+        [Description("Build configuration (Debug, Release, etc.) defaults to Debug.")]
+        string? buildConfiguration,
+        CancellationToken cancellationToken) {
 
         return await ErrorHandlingHelpers.ExecuteWithErrorHandlingAsync(async () => {
             ErrorHandlingHelpers.ValidateStringParameter(solutionPath, "solutionPath", logger);
@@ -59,7 +60,7 @@ public static class SolutionTools {
             }
 
             try {
-                await solutionManager.LoadSolutionAsync(solutionPath, cancellationToken);
+                await solutionManager.LoadSolutionAsync(solutionPath, buildConfiguration ?? "Debug", cancellationToken);
             } catch (Exception ex) when (!(ex is McpException || ex is OperationCanceledException)) {
                 logger.LogError(ex, "Failed to load solution at {SolutionPath}", solutionPath);
                 throw new McpException($"Failed to load solution: {ex.Message}");


### PR DESCRIPTION
I had been working with a prior version of this change awhile, but today as I went to create a pull-request I realized the build configuration was lost when the solution was reloaded. So I fixed that but haven't had time to really try this out locally. I wanted to create a PR though for review while I have time, to see if you can see other issues with this approach.

I was tempted to add a parameter for build run-time but I don't see what value that would add.

I did not add build configuration as a command-line parameter though solution path is a command-line parameter as it looks like that command line parameter is for your local testing and not something intended for general consumption (and I assume you don't need configuration as a command line parameter for your testing).