### PR TITLE
Add .slnf (solution filter) support and pack-as-tool config

### DIFF
--- a/SharpTools.StdioServer/SharpTools.StdioServer.csproj
+++ b/SharpTools.StdioServer/SharpTools.StdioServer.csproj
@@ -18,6 +18,8 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>sharptools-mcp</ToolCommandName>
   </PropertyGroup>
 
 </Project>

--- a/SharpTools.Tools/Mcp/Tools/SolutionTools.cs
+++ b/SharpTools.Tools/Mcp/Tools/SolutionTools.cs
@@ -40,7 +40,7 @@ public static class SolutionTools {
     ISolutionManager solutionManager,
     IEditorConfigProvider editorConfigProvider,
     ILogger<SolutionToolsLogCategory> logger,
-    [Description("The absolute file path to the .sln or .slnx solution file.")] string solutionPath,
+    [Description("The absolute file path to the .sln, .slnx, or .slnf (solution filter) solution file.")] string solutionPath,
     CancellationToken cancellationToken) {
 
         return await ErrorHandlingHelpers.ExecuteWithErrorHandlingAsync(async () => {
@@ -55,9 +55,10 @@ public static class SolutionTools {
 
             var ext = Path.GetExtension(solutionPath);
             if (!ext.Equals(".sln", StringComparison.OrdinalIgnoreCase) &&
-                !ext.Equals(".slnx", StringComparison.OrdinalIgnoreCase)) {
+                !ext.Equals(".slnx", StringComparison.OrdinalIgnoreCase) &&
+                !ext.Equals(".slnf", StringComparison.OrdinalIgnoreCase)) {
                 logger.LogError("File is not a valid solution file: {SolutionPath}", solutionPath);
-                throw new McpException($"File at path '{solutionPath}' is not a .sln or .slnx file.");
+                throw new McpException($"File at path '{solutionPath}' is not a .sln, .slnx, or .slnf file.");
             }
 
             try {

--- a/SharpTools.Tools/Services/SolutionManager.cs
+++ b/SharpTools.Tools/Services/SolutionManager.cs
@@ -20,6 +20,7 @@ public sealed class SolutionManager : ISolutionManager {
     public MSBuildWorkspace? CurrentWorkspace => _workspace;
     public Solution? CurrentSolution => _currentSolution;
     private readonly string? _buildConfiguration;
+    private string? _requestedSolutionPath;
 
     public SolutionManager(ILogger<SolutionManager> logger, IFuzzyFqnLookupService fuzzyFqnLookupService, string? buildConfiguration = null) {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -32,6 +33,7 @@ public sealed class SolutionManager : ISolutionManager {
             throw new FileNotFoundException("Solution file not found.", solutionPath);
         }
         UnloadSolution(); // Clears previous state including _allLoadedReflectionTypesCache
+        _requestedSolutionPath = solutionPath;
         try {
             _logger.LogInformation("Creating MSBuildWorkspace...");
             var properties = new Dictionary<string, string> {
@@ -204,6 +206,7 @@ public sealed class SolutionManager : ISolutionManager {
             _workspace.Dispose();
             _workspace = null;
         }
+        _requestedSolutionPath = null;
         _metadataLoadContext?.Dispose();
         _metadataLoadContext = null;
         _pathAssemblyResolver = null; // PathAssemblyResolver doesn't implement IDisposable
@@ -232,7 +235,8 @@ public sealed class SolutionManager : ISolutionManager {
             _logger.LogWarning("Cannot reload solution: No solution loaded.");
             return;
         }
-        await LoadSolutionAsync(_workspace.CurrentSolution.FilePath!, cancellationToken);
+        var pathToReload = _requestedSolutionPath ?? _workspace.CurrentSolution.FilePath!;
+        await LoadSolutionAsync(pathToReload, cancellationToken);
         _logger.LogDebug("Current solution state has been refreshed from workspace.");
     }
     private void OnWorkspaceFailed(object? sender, WorkspaceDiagnosticEventArgs e) {


### PR DESCRIPTION
## Summary

- **`.slnf` support in `SharpTool_LoadSolution`**: The tool now accepts `.slnf` solution filter files alongside `.sln` and `.slnx`. `MSBuildWorkspace.OpenSolutionAsync` in Roslyn 4.x+ natively handles `.slnf` — it reads the JSON filter, opens the referenced `.sln`, and excludes projects not listed, so no manual parsing or `RemoveProject` calls are needed.
- **Reload correctness fix**: Added `_requestedSolutionPath` to `SolutionManager` so `ReloadSolutionFromDiskAsync` re-uses the original `.slnf` path rather than the underlying `.sln` path that Roslyn stores in `Solution.FilePath`. Without this, a reload after loading a filter file would drop the filter and load all projects.
- **`PackAsTool` / `ToolCommandName`**: Added to `SharpTools.StdioServer.csproj` so the project can be packed and installed as a global .NET tool via `dotnet pack` + `dotnet tool install`.

## Motivation

Large solutions with many projects are slow to load and produce noisy output for AI agents. Solution filters let users pre-scope the workspace to only the projects relevant to their task, making `SharpTool_LoadSolution` faster and more focused.

## Test plan

- [x] Build passes with no new errors (`dotnet build`)
- [x] Loaded a `.slnf` file selecting 1 of 3 projects in SharpToolsMCP itself — confirmed `Solution loaded successfully with 1 projects` in logs
- [x] Confirmed the `SharpTool_LoadSolution` MCP tool accepted the `.slnf` path through the full JSON-RPC call path
- [x] Confirmed `dotnet pack` + `dotnet tool install` works with the new csproj properties

🤖 Generated with [Claude Code](https://claude.com/claude-code)